### PR TITLE
feat: add server selection behavior setting with auto-open channel selector option a la Discord

### DIFF
--- a/app/src/main/java/chat/revolt/api/schemas/Settings.kt
+++ b/app/src/main/java/chat/revolt/api/schemas/Settings.kt
@@ -54,6 +54,11 @@ data class AndroidSpecificSettings(
      */
     var messageReplyStyle: String? = null,
     /**
+     * Server selection behavior.
+     * Can be one of `{ LastChannel, ShowChannelList }`
+     */
+    var serverSelectionBehavior: String? = null,
+    /**
      * Avatar radius.
      * Must be integer in range 0..50 inclusive.
      */

--- a/app/src/main/java/chat/revolt/api/settings/LoadedSettings.kt
+++ b/app/src/main/java/chat/revolt/api/settings/LoadedSettings.kt
@@ -14,11 +14,17 @@ enum class MessageReplyStyle {
     DoubleTap
 }
 
+enum class ServerSelectionBehavior {
+    LastChannel,
+    ShowChannelList
+}
+
 typealias SpecialEmbedSettings = AndroidSpecificSettingsSpecialEmbedSettings
 
 object LoadedSettings {
     var theme by mutableStateOf(getDefaultTheme())
     var messageReplyStyle by mutableStateOf(MessageReplyStyle.SwipeFromEnd)
+    var serverSelectionBehavior by mutableStateOf(ServerSelectionBehavior.LastChannel)
     var avatarRadius by mutableIntStateOf(50)
     var experimentsEnabled by mutableStateOf(false)
     var specialEmbedSettings by mutableStateOf(SpecialEmbedSettings())
@@ -29,6 +35,9 @@ object LoadedSettings {
         this.messageReplyStyle =
             settings.android.messageReplyStyle?.let { MessageReplyStyle.valueOf(it) }
                 ?: MessageReplyStyle.SwipeFromEnd
+        this.serverSelectionBehavior =
+            settings.android.serverSelectionBehavior?.let { ServerSelectionBehavior.valueOf(it) }
+                ?: ServerSelectionBehavior.LastChannel
         this.avatarRadius = settings.android.avatarRadius ?: 50
         this.specialEmbedSettings = settings.android.specialEmbedSettings ?: SpecialEmbedSettings()
     }
@@ -36,6 +45,7 @@ object LoadedSettings {
     fun reset() {
         theme = getDefaultTheme()
         messageReplyStyle = MessageReplyStyle.SwipeFromEnd
+        serverSelectionBehavior = ServerSelectionBehavior.LastChannel
         avatarRadius = 50
         specialEmbedSettings = SpecialEmbedSettings()
         poorlyFormedSettingsKeys = emptySet()

--- a/app/src/main/java/chat/revolt/api/settings/SyncedSettings.kt
+++ b/app/src/main/java/chat/revolt/api/settings/SyncedSettings.kt
@@ -28,7 +28,8 @@ object SyncedSettings {
         AndroidSpecificSettings(
             theme = "None",
             colourOverrides = null,
-            messageReplyStyle = "None"
+            messageReplyStyle = "None",
+            serverSelectionBehavior = "LastChannel"
         )
     )
     private val _notifications = mutableStateOf(NotificationSettings())
@@ -131,7 +132,8 @@ object SyncedSettings {
         val default = AndroidSpecificSettings(
             theme = "None",
             colourOverrides = null,
-            messageReplyStyle = "None"
+            messageReplyStyle = "None",
+            serverSelectionBehavior = "LastChannel"
         )
         _android.value = default
         setKey("android", RevoltJson.encodeToString(AndroidSpecificSettings.serializer(), default))

--- a/app/src/main/java/chat/revolt/screens/settings/ChatSettingsScreen.kt
+++ b/app/src/main/java/chat/revolt/screens/settings/ChatSettingsScreen.kt
@@ -40,6 +40,7 @@ import androidx.navigation.NavController
 import chat.revolt.R
 import chat.revolt.api.settings.LoadedSettings
 import chat.revolt.api.settings.MessageReplyStyle
+import chat.revolt.api.settings.ServerSelectionBehavior
 import chat.revolt.api.settings.SpecialEmbedSettings
 import chat.revolt.api.settings.SyncedSettings
 import chat.revolt.composables.generic.ListHeader
@@ -51,6 +52,13 @@ class ChatSettingsScreenViewModel : ViewModel() {
         viewModelScope.launch {
             SyncedSettings.updateAndroid(SyncedSettings.android.copy(messageReplyStyle = next.name))
             LoadedSettings.messageReplyStyle = next
+        }
+    }
+
+    fun updateServerSelectionBehavior(next: ServerSelectionBehavior) {
+        viewModelScope.launch {
+            SyncedSettings.updateAndroid(SyncedSettings.android.copy(serverSelectionBehavior = next.name))
+            LoadedSettings.serverSelectionBehavior = next
         }
     }
 
@@ -195,6 +203,31 @@ fun ChatSettingsScreen(
                     selected = LoadedSettings.messageReplyStyle == MessageReplyStyle.DoubleTap,
                     onClick = { viewModel.updateMessageReplyStyle(MessageReplyStyle.DoubleTap) },
                     label = { Text(text = stringResource(R.string.settings_chat_quick_reply_double_tap)) }
+                )
+            }
+
+            ListHeader {
+                Text(
+                    text = "Server Selection"
+                )
+            }
+
+            Column(Modifier.selectableGroup()) {
+                RadioItem(
+                    selected = LoadedSettings.serverSelectionBehavior == ServerSelectionBehavior.LastChannel,
+                    onClick = { viewModel.updateServerSelectionBehavior(ServerSelectionBehavior.LastChannel) },
+                    label = { Text(text = "Go to Last Channel") },
+                    description = {
+                        Text(text = "Navigate directly to the last used channel when selecting a server")
+                    }
+                )
+                RadioItem(
+                    selected = LoadedSettings.serverSelectionBehavior == ServerSelectionBehavior.ShowChannelList,
+                    onClick = { viewModel.updateServerSelectionBehavior(ServerSelectionBehavior.ShowChannelList) },
+                    label = { Text(text = "Show Channel List") },
+                    description = {
+                        Text(text = "Open the channel list automatically after navigating to the last used channel")
+                    }
                 )
             }
 


### PR DESCRIPTION
This update allows users to change chat settings where selecting a new server will automatically open the channel selector for that server instead of the last read channel.

<img width="1074" height="631" alt="image" src="https://github.com/user-attachments/assets/0818c101-7c15-4bea-8266-2079bb296b6f" />
